### PR TITLE
Use Go version 1.14 in the GitHub actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: '^1.14'
       id: go
 
     - name: Check out code into the Go module directory
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: '^1.14'
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>